### PR TITLE
Fix code lesson

### DIFF
--- a/src/services/code.service.js
+++ b/src/services/code.service.js
@@ -4,8 +4,17 @@ const axios = require('axios')
 class CodeService {
   async #runCode({ language, code, rawTests, logFunc }) {
     let isCodeValid = true
+    const splitter = '|'
     let errorMsg = ''
-    const tests = `${logFunc}(${rawTests.map((testObj) => testObj.test).join(', ')})`
+
+    const testsBody = rawTests.map((testObj) => {
+      if (testObj.test.includes('(') && testObj.test.includes(')')) {
+        return testObj.test
+      }
+      return `\"${testObj.test}\"`
+    }).join(`, '${splitter}' ,`)
+
+    const tests = `${logFunc}(${testsBody})`
 
     const codeForRun = `${code}\n\n${tests}`
 
@@ -25,10 +34,10 @@ class CodeService {
       errorMsg = execCodeData.output
     }
 
-    const results = execCodeData.output.split(' ').map((elem) => elem.replace('\n', ''))
+    const results = execCodeData.output.split(' \'|\' ').map((elem) => elem.replace('\n', ''))
 
     results.forEach((res, index) => {
-      if (rawTests[index]?.expected !== res) {
+      if (rawTests[index]?.expected !== res && !res.includes(rawTests[index].expected.trim())) {
         if (!errorMsg) {
           errorMsg += `Wrong output for ${rawTests[index]?.test}\n`
         }

--- a/src/services/code.service.js
+++ b/src/services/code.service.js
@@ -37,7 +37,7 @@ class CodeService {
     const results = execCodeData.output.split(' \'|\' ').map((elem) => elem.replace('\n', ''))
 
     results.forEach((res, index) => {
-      if (rawTests[index]?.expected !== res && !res.includes(rawTests[index].expected.trim())) {
+      if (rawTests[index]?.expected !== res && !res.includes(rawTests[index].expected)) {
         if (!errorMsg) {
           errorMsg += `Wrong output for ${rawTests[index]?.test}\n`
         }


### PR DESCRIPTION
Now code lessons can pass such examples: 

```json
{
  "tests": [
    {
      "_id": "626d902a90630f676c35bb00",
      "test": "sum(5, 5)",
      "expected": "10"
    },
    {
      "_id": "626d902a90630f676c35bb01",
      "test": "sum(20, 20)",
      "expected": "40"
    }
  ],
  "language": "nodejs",
  "code": "const sum = (a, b) => a + b"
}
```

and 

```json
{
  "tests": [
    {
      "_id": "626d902a90630f676c35bb00",
      "test": "Hello, World",
      "expected": "Hello, World"
    }
  ],
  "language": "nodejs",
  "code": "console.log(\"Hello, World\")"
}
```

